### PR TITLE
Security fix for Prototype Pollution vulnerability

### DIFF
--- a/src/util/set-path-value.js
+++ b/src/util/set-path-value.js
@@ -4,7 +4,7 @@ module.exports = function setPathValue(obj, path, value) {
   let state = obj;
   const last = paths[paths.length - 1];
   for (let i = 0; i < paths.length - 1; i++) {
-    state = state && state[paths[i]];
+    state = state && state[paths[i]] !== Object.prototype && state[paths[i]];
   }
   if (!state) return false;
   if (value !== state[last]) {

--- a/util/set-path-value.js
+++ b/util/set-path-value.js
@@ -4,7 +4,7 @@ module.exports = function setPathValue(obj, path, value) {
   var state = obj;
   var last = paths[paths.length - 1];
   for (var i = 0; i < paths.length - 1; i++) {
-    state = state && state[paths[i]];
+    state = state && state[paths[i]] !== Object.prototype && state[paths[i]];
   }
   if (!state) { return false; }
   if (value !== state[last]) {


### PR DESCRIPTION
### :bar_chart: Metadata *

`xkit` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-xkit

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const set = require('xkit/util/set-path-value')

console.log('Before:', {}.polluted)
set({}, '__proto__.polluted', true)
console.log('After:', {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i xkit # Install vulerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/115115487-52f95880-9fb2-11eb-87f1-bdcfd7bc51b2.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
